### PR TITLE
♻️ refactor (Contenu): ordre mediatheque et limite actualité

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -12,7 +12,7 @@ export async function navQuery(lang) {
       childItems {
         nodes {
           label
-          uri                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+          uri                       
         }
       }
     }
@@ -32,7 +32,7 @@ export async function newsPagePostsQuery(lang) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       query: `{
-                posts(where: {language: ${lang}}) {
+                posts(first:1000, where: {language: ${lang}}) {
                   nodes {
                     date
                     uri
@@ -231,7 +231,7 @@ export async function getYoutubeURL() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       query: `{
-        mediatheques(where: {status: PUBLISH, orderby: {field: DATE, order: ASC}}) {
+        mediatheques(where: {status: PUBLISH, orderby: {field: DATE, order: DESC}}) {
                       nodes {
                         lien {
                           lien


### PR DESCRIPTION
**Changements Apportés :**

Réorganisation de l'Ordre dans Médiathèque :
Limite d'Actualités

**Raison du Changement :**
Ces ajustements ont été effectués en réponse aux préoccupations spécifiques soulevées lors de la session avec l'équipe CitizenLabRIM. L'objectif est de garantir que les utilisateurs puissent accéder à l'ensemble des ressources disponibles tout en mettant en avant les contenus les plus récents, en particulier les vidéos