### PR TITLE
♻️ refactor (Actualites): redimensionnement image preview dans liste et definir une image par defaut

### DIFF
--- a/src/components/blog/wpListItem.astro
+++ b/src/components/blog/wpListItem.astro
@@ -15,30 +15,36 @@ export interface Props {
 }
 
 const { post } = Astro.props;
-const image = await findImage(post.featuredImage?.node?.mediaItemUrl);
+
+const imagePromise = findImage(post.featuredImage?.node?.mediaItemUrl);
+const imageDefaut = 'https://citizenlabmauritanie.africtivistes.org/wp-content/uploads/2023/03/WhatsApp-Image-2023-02-19-at-19.43.53.jpeg';
+const image = await imagePromise.catch(() => null);
+const src = image ? image : imageDefaut;
+
 const datePost = Date.parse(post.date);
 const link = !BLOG?.post?.disabled ? getPermalink(post.uri, 'post') : '';
 
 ---
 
-<article class={`max-w-md mx-auto md:max-w-none grid gap-6 md:gap-8 ${image ? 'md:grid-cols-2' : ''}`}>
+<article class={`max-w-md mx-auto md:max-w-none grid gap-6 md:gap-8 ${src ? 'md:grid-cols-2' : ''}`}>
   {
-    image && (
+    src && (
       <a class="relative block group" href={link ?? 'javascript:void(0)'}>
-        <div class="relative h-0 pb-[56.25%] md:pb-[75%] md:h-72 lg:pb-[56.25%] overflow-hidden bg-gray-400 dark:bg-slate-700 rounded shadow-lg">
-          {image && (
+          {src && (
             <Picture
-              src={image}
-              class="absolute inset-0 object-cover w-full h-full mb-6 rounded shadow-lg bg-gray-400 dark:bg-slate-700"
-              widths={[400, 900]}
-              sizes="(max-width: 900px) 400px, 900px"
-              alt={post.title}
-              aspectRatio="16:9"
-              loading="lazy"
-              decoding="async"
-            />
+            src={src}
+            class="max-w-full mt-7 lg:max-w-6xl mx-auto mb-6 sm:rounded-md bg-gray-400 dark:bg-slate-700"
+            widths={[400, 900]}
+            sizes="(max-width: 900px) 400px, 900px"
+            alt={post.description || 'defaut'}
+            aspectRatio="3:3"
+            loading="eager"
+            width={400}
+            height={300}
+            loading="eager"
+            decoding="async"
+          />
           )}
-        </div>
       </a>
     )
   }

--- a/src/components/blog/wpPost.astro
+++ b/src/components/blog/wpPost.astro
@@ -22,7 +22,7 @@ const currentPath = Astro.url.href;
 <section class="py-8 sm:py-16 lg:py-20 mx-auto">
   <article>
     <header class={post.image ? '' : ''}>
-      <div class="flex justify-between flex-col sm:flex-row max-w-3xl mx-auto mt-0 mb-2 px-4 sm:px-6 sm:items-center">
+      <div class="flex justify-between flex-col sm:flex-row max-w-3xl mx-auto mt-5 mb-2 px-4 sm:px-6 sm:items-center">
         <p>
           <Icon name="tabler:clock" class="w-4 h-4 inline-block -mt-0.5 dark:text-gray-400" />
           <time datetime={String(post.date)}>{getFormattedDate(datePost)}</time>
@@ -45,12 +45,7 @@ const currentPath = Astro.url.href;
       >
         {post.title}
       </h1>
-      <div
-        class="max-w-3xl mx-auto mt-4 mb-8 px-4 sm:px-6 text-xl md:text-2xl text-muted dark:text-slate-400 text-justify"
-      >
-        <!-- {post.excerpt} -->
-        <Fragment set:html={post.excerpt} />
-      </div>
+      
 
       {
         post.image ? (
@@ -60,13 +55,11 @@ const currentPath = Astro.url.href;
             widths={[400, 900]}
             sizes="(max-width: 900px) 400px, 900px"
             alt={post.description || ''}
+            aspectRatio='4:4'
             loading="eager"
-            aspectRatio={16 / 9}
-            width={900}
-            height={506}
-            loading="eager"
+            width={750}
+            height={750}
             decoding="async"
-            background={undefined}
           />
         ) : (
           <div class="max-w-3xl mx-auto px-4 sm:px-6">

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -39,7 +39,7 @@ const CONFIG = {
 
   actualites: {
     disabled: false,
-    postsPerPage: 4,
+    postsPerPage: 10,
 
     post: {
       permalink: '/%slug%', // Variables: %slug%, %year%, %month%, %day%, %hour%, %minute%, %second%, %category%


### PR DESCRIPTION
L'objectif est de fixer le format des images dans la liste des articles mais aussi definir une image par defaut pour les articles qui n''ont pas d'images de mise en avant
En plus le nombre d'articles par page actualites est augmente a 10 par page